### PR TITLE
Small bugfix for MSGF+ v2017

### DIFF
--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -9,10 +9,10 @@ Beta stage. If you find typos, please fix them :)
 Summary
 *******
 
-In general, contribution to Ursgal is very welcome! Feel free to fork an/or clone
+In general, contribution to Ursgal is very welcome! Feel free to fork and/or clone
 Ursgal. If you want to improve code or contribute new nodes/tools/algorithms
 please read these guidelines first. If something is unclear please contact one
-of the authors for help or let us kknow via e.g. an issue.
+of the authors for help or let us know via e.g. an issue.
 
 
 Commit messages
@@ -29,7 +29,7 @@ Parameters
 **********
 
 The central idea of Ursgal are the unified parameters. The central parameter is 
-tranlated, so that every engine can use it. This means, if oyu implement a new
+tranlated, so that every engine can use it. This means, if you implement a new
 engine, you have to go through the (more or less) tedious process to check, if
 parameter X of the new engine Y is already listed in uparams.py. We require
 to be very thorough in this process. Having the same parameter multiple times
@@ -43,7 +43,7 @@ Code standards and conventions
 ******************************
 
 Since this a collaborative project, you will encounter different coding styles.
-Despite the fact that we know that diversity is beatiful, we need to keep some
+Despite the fact that we know that diversity is beautiful, we need to keep some
 common line on how to code (This list may be further extended). Please refer
 also to the PEP8 style guide, which we use generally 
 https://www.python.org/dev/peps/pep-0008/). Additionally this list will give
@@ -79,7 +79,7 @@ Merge/pull requests
 
 Please use the pull request to push your code to the master repository. It will
 be automatically tested by Travis and AppVeyor if the module is still working in
-unix and Windows environments. Pull request wil, be discussed by the main dev
+unix and Windows environments. Pull requests will be discussed by the main dev
 team and merged into Ursgal.
 
 
@@ -92,7 +92,7 @@ may directly open a pull requets. On the other hand, if you plan to or
 are already working on implementing new stuff, you may also open an issue and
 (pre-) announce your contribution. Please tag then the issue with
 'enhancement'. In general the core team of Ursgal will also take care of crucial
-bugs in the main code. Since Ursgal is open source, we can not maintain every
+bugs in the main code. Since Ursgal is open source, we cannot maintain every
 and assure its compatibility and functionality (please be reminded here to test
 your code, seriously, test your code)
 
@@ -114,7 +114,7 @@ DOI:10.1021/acs.jproteome.5b00860*
 .. note::
 
     Pip is included in Python 3.4 and higher. However, it might not be
-    included in in your system's PATH environment variable.
+    included in your system's PATH environment variable.
     If this is the case, you can either add the Python scripts directory to your
     PATH env variable or use the path to the pip.exe directly for the
     installation, e.g.: ~/Python34/Scripts/pip.exe install -r requirements.txt
@@ -126,7 +126,8 @@ Copyrights
 
 Copyright 2014-2015 by authors and contributors in alphabetical order
 
-* Christian Fufezan,
+* Christian Fufezan
+* Manuel Koesters
 * Lukas P. M. Kremer
 * Johannes Leufken
 * Purevdulam Oyunchimeg

--- a/CONTRIBUTE.rst
+++ b/CONTRIBUTE.rst
@@ -1,0 +1,139 @@
+Contribution guidelines
+#######################
+
+Beta stage. If you find typos, please fix them :)
+
+*Ursgal - Universal Python Module Combining Common Bottom-Up Proteomics Tools for Large-Scale Analysis*
+
+
+Summary
+*******
+
+In general, contribution to Ursgal is very welcome! Feel free to fork an/or clone
+Ursgal. If you want to improve code or contribute new nodes/tools/algorithms
+please read these guidelines first. If something is unclear please contact one
+of the authors for help or let us kknow via e.g. an issue.
+
+
+Commit messages
+***************
+
+First of all, please be concise and as descriptive (explicit is better than 
+implicit :) ) as possible. It is always
+helpful to point out, which parts of Ursgal were changed/fixed (e.g.
+documentation or example scripts etc. ). In the same time, please avoid
+unneccesarily long messages.
+
+
+Parameters
+**********
+
+The central idea of Ursgal are the unified parameters. The central parameter is 
+tranlated, so that every engine can use it. This means, if oyu implement a new
+engine, you have to go through the (more or less) tedious process to check, if
+parameter X of the new engine Y is already listed in uparams.py. We require
+to be very thorough in this process. Having the same parameter multiple times
+must be avoided! There may be difficult cases, to decide if the parameter is
+actually the same, but by using the translation system in Ursgal, some
+adjusments can be made. Please refer to the documentation for further
+instructions and considerations on the parameters.
+
+
+Code standards and conventions
+******************************
+
+Since this a collaborative project, you will encounter different coding styles.
+Despite the fact that we know that diversity is beatiful, we need to keep some
+common line on how to code (This list may be further extended). Please refer
+also to the PEP8 style guide, which we use generally 
+https://www.python.org/dev/peps/pep-0008/). Additionally this list will give
+you some things to think about:
+
+  | Re-think naming of variables at least twice
+
+
+
+Test philosophy
+***************
+
+Test your code! Seriously, test you code! If you add new functionality or nodes
+at the same time provide (a) test function(s). We have already a set of tests
+and different files, which can be used for the test. Avoid adding new test files
+if possible to keep the repo small.
+
+
+Sphinx guide
+************
+
+We use Sphinx to automatically build and format the documentation. Please keep
+this style in your docstrings
+
+
+Other rules and cosiderations
+*****************************
+
+None so far.
+
+Merge/pull requests
+*******************
+
+Please use the pull request to push your code to the master repository. It will
+be automatically tested by Travis and AppVeyor if the module is still working in
+unix and Windows environments. Pull request wil, be discussed by the main dev
+team and merged into Ursgal.
+
+
+Issues
+****** 
+
+If you have an issue or problem, please first search all open issues and pull
+request to avoid duplication of efforts. If you have a fix for the problem you
+may directly open a pull requets. On the other hand, if you plan to or
+are already working on implementing new stuff, you may also open an issue and
+(pre-) announce your contribution. Please tag then the issue with
+'enhancement'. In general the core team of Ursgal will also take care of crucial
+bugs in the main code. Since Ursgal is open source, we can not maintain every
+and assure its compatibility and functionality (please be reminded here to test
+your code, seriously, test your code)
+
+
+Citation
+********
+
+If you use Ursagl, do not forget to cite us
+
+*Kremer, L. P. M., Leufken, J., Oyunchimeg, P., Schulze, S. and Fufezan, C.
+(2015):* |publicationtitle|_ *, Journal of Proteome research, 15, 788-.
+DOI:10.1021/acs.jproteome.5b00860*
+
+.. _publicationtitle: http://dx.doi.org/10.1021/acs.jproteome.5b00860
+.. |publicationtitle| replace:: *Ursgal, Universal Python Module Combining Common Bottom-Up Proteomics Tools for Large-Scale Analysis*
+
+
+
+.. note::
+
+    Pip is included in Python 3.4 and higher. However, it might not be
+    included in in your system's PATH environment variable.
+    If this is the case, you can either add the Python scripts directory to your
+    PATH env variable or use the path to the pip.exe directly for the
+    installation, e.g.: ~/Python34/Scripts/pip.exe install -r requirements.txt
+
+
+
+Copyrights
+***********
+
+Copyright 2014-2015 by authors and contributors in alphabetical order
+
+* Christian Fufezan,
+* Lukas P. M. Kremer
+* Johannes Leufken
+* Purevdulam Oyunchimeg
+* Stefan Schulze
+* Kazuhiko Sugimoto
+* Lukas Vaut
+
+
+
+

--- a/ursgal/wrappers/msgfplus2csv_v2017_01_27.py
+++ b/ursgal/wrappers/msgfplus2csv_v2017_01_27.py
@@ -30,7 +30,7 @@ class msgfplus2csv_v2017_01_27( msgf2csv ):
         'engine_type' : {
             'converter'     : True
         },
-        'input_extensions'   : ['.mzid'],
+        'input_extensions'   : ['.mzid', '.mzid.gz'],
         'input_multi_file'   : False,
         'output_extensions'  : ['.csv'],
         'output_suffix'      : None,

--- a/ursgal/wrappers/msgfplus_v2017_01_27.py
+++ b/ursgal/wrappers/msgfplus_v2017_01_27.py
@@ -35,7 +35,7 @@ class msgfplus_v2017_01_27( msgf ):
             '.dta.txt'
         ],
         'input_multi_file'            : False,
-        'output_extensions'           : ['.mzid'],
+        'output_extensions'           : ['.mzid', '.mzid.gz'],
         'compress_raw_search_results' : True,
         'create_own_folder'           : True,
         'in_development'              : False,


### PR DESCRIPTION
Version 2017 crashes since mzid output will be compressed, but this was not defined as a valid output extension.