### PR TITLE
docu, utags and naming updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,13 +36,17 @@ Summary
 
 Ursgal is a Python module that offers a generalized interface to common bottom-up proteomics tools, e.g.
 
-    a) Peptide spectrum matching with up to five different search engines (some available in multiple versions)
+    a) Peptide spectrum matching with up to eight different search engines (some available in multiple versions),
+      including three open modification search engines
 
     b) Evaluation and post processing of search results with up to two different engines
 
     c) Integration of search results from different search engines
 
-    d) Creation of a target decoy database
+    d) De novo sequencing with up to two different search engines
+
+    e) Miscellaneous tools including the creation of a target decoy database as well as filtering, sanitizing
+      and visualizing of results
 
 Abstract
 ********

--- a/docs/uparams_to_dash.py
+++ b/docs/uparams_to_dash.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3.4
+# encoding: utf-8
+
+import sys
+import os
+import pprint
+sys.path.insert(0, os.path.abspath('../'))
+from ursgal.uparams import ursgal_params
+from collections import defaultdict as ddict
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+
+
+def sort_params(uparams, sort_by=None):
+    if sort_by is None:
+        return uparams
+    sorted_params = {}
+    for ukey in uparams.keys():
+        if type(uparams[ukey][sort_by]) in [list, dict]:
+            for element in uparams[ukey][sort_by]:
+                if element not in sorted_params.keys():
+                    sorted_params[element] = {}
+                sorted_params[element][ukey] = uparams[ukey]
+        else:
+            element = uparams[ukey][sort_by]
+            if element not in sorted_params.keys():
+                sorted_params[element] = {}
+            sorted_params[element][ukey] = uparams[ukey]
+    return sorted_params
+
+app = dash.Dash()
+
+colors = {
+    'background_header': '#297FB8',
+    'text_header': '#FCFFFF'
+}
+
+available_engines = []
+unode_sorted_uparams = sort_params(ursgal_params, sort_by='available_in_unode')
+for unode in sorted(unode_sorted_uparams.keys()):
+    available_engines.append(unode)
+
+available_tags = []
+utag_sorted_uparams = sort_params(ursgal_params, sort_by='utag')
+for utag in sorted(utag_sorted_uparams):
+    available_tags.append(utag)
+
+app.layout = html.Div([
+    html.Div([
+        dcc.Markdown(
+            '''
+.
+''',
+            containerProps={
+                'style': {
+                    'color': 'rgb(30, 120, 210)',
+                }, })
+    ], style={
+        'backgroundColor': 'rgb(30, 120, 210)',
+    },),
+
+    html.Div([
+        dcc.Markdown('''
+# Ursgal Parameters
+A searchable list of all parameters in Ursgal.
+Use the dropdown options to select one or multiple engines or tags \
+for which the corresponding parameters should be displayed
+
+        ''',
+                     containerProps={
+                         'style': {
+                             'color': 'rgb(35, 35, 35)',
+                         }, })
+    ], style={
+        'marginLeft': 10,
+        'marginRight': 10,
+    }),
+
+    html.Div([
+        dcc.Markdown('**UParams**'),
+        dcc.RadioItems(
+            id='uparams_radio',
+            options=[
+                {'label': 'All uparams', 'value': 'all_uparams'},
+                {'label': 'Select uparams', 'value': 'select_uparams'},
+            ],
+            value='all_uparams',
+            labelStyle={'display': 'inline-block'}
+        ),
+        dcc.Dropdown(
+            id='params',
+            value='all_uparams',
+            multi=True
+        ),
+    ], style={
+        'width': '32%',
+        'marginLeft': 10,
+        'marginRight': 10,
+        'display': 'inline-block',
+        'backgroundColor': 'rgb(250, 250, 250)',
+        'color': 'rgb(35, 35, 35)',
+    }),
+
+    html.Div([
+        dcc.Markdown('**Engines**'),
+        dcc.RadioItems(
+            id='engines_radio',
+            options=[
+                {'label': 'All engines', 'value': 'all_engines'},
+                {'label': 'Select engines', 'value': 'select_engines'},
+            ],
+            value='all_engines',
+            labelStyle={'display': 'inline-block'}
+        ),
+        dcc.Dropdown(
+            id='engine',
+            value='all_engines',
+            multi=True
+        ),
+    ], style={
+        'width': '32%',
+        'marginLeft': 10,
+        'display': 'inline-block',
+        'backgroundColor': 'rgb(250, 250, 250)',
+        'color': 'rgb(35, 35, 35)',
+    }),
+
+    html.Div([
+        dcc.Markdown('**Tags**'),
+        dcc.RadioItems(
+            id='tags_radio',
+            options=[
+                {'label': 'All tags', 'value': 'all_tags'},
+                {'label': 'Select tags', 'value': 'select_tags'},
+            ],
+            value='all_tags',
+            labelStyle={'display': 'inline-block'}
+        ),
+        dcc.Dropdown(
+            id='tag',
+            value='all_tags',
+            multi=True
+        ),
+    ], style={
+        'width': '32%',
+        'display': 'inline-block',
+        'backgroundColor': 'rgb(250, 250, 250)',
+        'color': 'rgb(35, 35, 35)',
+    }),
+
+    html.Div([
+        dcc.Checklist(
+            id='text_options',
+            options=[
+                {'label': 'Show Unodes for each parameter',
+                    'value': 'available_unodes'},
+                {'label': 'Show Ursgal tags',
+                    'value': 'show_utags'},
+                {'label': 'Show Ursgal value translations',
+                    'value': 'uvalue_translation'},
+                {'label': 'Show Ursgal key translations',
+                    'value': 'ukey_translation'},
+            ],
+            values=['available_unodes'],
+            # labelStyle={'display': 'inline-block'}
+        ),
+    ], style={
+        'marginLeft': 10,
+        'marginRight': 10,
+        'backgroundColor': 'rgb(250, 250, 250)',
+        'color': 'rgb(35, 35, 35)',
+    },),
+
+    html.Div([
+        dcc.Markdown(
+            '''
+.
+''',
+            containerProps={
+                'style': {
+                    'color': 'rgb(30, 120, 210)',
+                }, })
+    ], style={
+        'backgroundColor': 'rgb(30, 120, 210)',
+    },),
+
+    html.Div([
+        dcc.Markdown(
+            id='selected_params',
+            containerProps={
+                'style': {
+                    'color': 'rgb(37, 37, 37)',
+                },
+            },
+        ),
+    ], style={
+        'marginLeft': 30,
+        'marginRight': 10,
+        'backgroundColor': 'rgb(250, 250, 250)',
+    },)
+], style={
+    'backgroundColor': 'rgb(250, 250, 250)'
+},)
+
+
+@app.callback(
+    dash.dependencies.Output('params', 'options'),
+    [dash.dependencies.Input('uparams_radio', 'value'), ])
+def set_uparams_dropdown(selected_uparams):
+    if selected_uparams == 'all_uparams':
+        return [{'disabled': True}]
+    if selected_uparams == 'select_uparams':
+        return [{'label': i, 'value': i} for i in sorted(ursgal_params) if i != '']
+
+
+@app.callback(
+    dash.dependencies.Output('params', 'value'),
+    [dash.dependencies.Input('uparams_radio', 'value'), ])
+def set_engines_value(selected_uparams):
+    if selected_uparams == 'all_uparams':
+        return 'all_uparams'
+    if selected_uparams == 'select_uparams':
+        return []
+
+
+@app.callback(
+    dash.dependencies.Output('engine', 'options'),
+    [dash.dependencies.Input('engines_radio', 'value'), ])
+def set_engines_dropdown(selected_engines):
+    if selected_engines == 'all_engines':
+        return [{'disabled': True}]
+    if selected_engines == 'select_engines':
+        return [{'label': i, 'value': i} for i in sorted(available_engines) if i != '']
+
+
+@app.callback(
+    dash.dependencies.Output('engine', 'value'),
+    [dash.dependencies.Input('engines_radio', 'value'), ])
+def set_engines_value(selected_engines):
+    if selected_engines == 'all_engines':
+        return 'all_engines'
+    if selected_engines == 'select_engines':
+        return []
+
+
+@app.callback(
+    dash.dependencies.Output('tag', 'options'),
+    [dash.dependencies.Input('tags_radio', 'value'), ])
+def set_engines_dropdown(selected_tags):
+    if selected_tags == 'all_tags':
+        return [{'disabled': True}]
+    if selected_tags == 'select_tags':
+        return [{'label': i, 'value': i} for i in sorted(available_tags) if i != '']
+
+
+@app.callback(
+    dash.dependencies.Output('tag', 'value'),
+    [dash.dependencies.Input('tags_radio', 'value'), ])
+def set_engines_dropdown(selected_tags):
+    if selected_tags == 'all_tags':
+        return 'all_tags'
+    if selected_tags == 'select_tags':
+        return []
+
+
+@app.callback(
+    dash.dependencies.Output('selected_params', 'children'),
+    [dash.dependencies.Input('engine', 'value'),
+     dash.dependencies.Input('params', 'value'),
+     dash.dependencies.Input('tag', 'value'),
+     dash.dependencies.Input('text_options', 'values'), ])
+def update_text(selected_engines, selected_uparams, selected_tags, selected_text_options):
+    if selected_uparams == 'all_uparams':
+        uparams = ursgal_params
+    else:
+        uparams = {}
+        for ukey in selected_uparams:
+            uparams[ukey] = ursgal_params[ukey]
+    if selected_engines == 'all_engines':
+        engine_params = uparams
+    else:
+        engine_params = {}
+        for unode in selected_engines:
+            for ukey in unode_sorted_uparams[unode]:
+                if ukey not in uparams.keys():
+                    continue
+                if ukey not in engine_params.keys():
+                    engine_params[ukey] = ursgal_params[ukey]
+                else:
+                    continue
+    if selected_tags == 'all_tags':
+        tag_engine_params = engine_params
+    else:
+        tag_engine_params = {}
+        for utag in selected_tags:
+            for ukey in utag_sorted_uparams[utag]:
+                if ukey not in engine_params.keys():
+                    continue
+                if ukey not in tag_engine_params.keys():
+                    tag_engine_params[ukey] = ursgal_params[ukey]
+                else:
+                    continue
+
+    text = []
+    for ursgal_param, udict in sorted(tag_engine_params.items()):
+        if isinstance(udict['default_value'], dict):
+            default_value = str(sorted(udict['default_value'])).strip()
+        else:
+            default_value = str(udict['default_value']).strip()
+        text.append(
+            '''
+## {0}
+
+> {desc}
+
+> **Default value**: {default_value} \n
+> **type**: {type} \n
+> **triggers rerun**: {rerun} \n
+'''.format(
+                ursgal_param,
+                desc=udict['description'].strip(),
+                default_value=default_value,
+                type=udict.get('uvalue_type', ''),
+                rerun=udict.get('trigger_rerun', 'False')
+            )
+        )
+        if 'available_unodes' in selected_text_options:
+            text.append(
+                '''
+### Available in unodes:
+''')
+            for unode in udict['available_in_unode']:
+                text.append('* {0}'.format(unode))
+
+        if 'show_utags' in selected_text_options:
+            text.append(
+                '''
+### Ursgal tags:
+''')
+            for utag in udict['utag']:
+                text.append('* {0}'.format(utag))
+
+        if 'ukey_translation' in selected_text_options:
+            text.append('''
+### Ursgal key translations for {0}:
+'''.format(ursgal_param)
+            )
+            for style, translation in sorted(udict['ukey_translation'].items()):
+                text.append('* {0}: {1}'.format(
+                    style,
+                    translation)
+                )
+
+        if 'uvalue_translation' in selected_text_options:
+            text.append('''
+### Ursgal value translations for {0}:
+'''.format(ursgal_param)
+            )
+            for style, translation in sorted(udict['uvalue_translation'].items()):
+                if type(translation) is dict:
+                    text.append(
+                        '''* {0}: {1}'''.format(
+                            style,
+                            translation)
+                    )
+        text.append(
+            '---------------')
+    return '\n'.join(text)
+
+if __name__ == '__main__':
+    print('Collecting uparams ...')
+    print(len(ursgal_params))
+    app.run_server(debug=True)

--- a/docs/uparams_to_dash.py
+++ b/docs/uparams_to_dash.py
@@ -153,7 +153,7 @@ for which the corresponding parameters should be displayed
         dcc.Checklist(
             id='text_options',
             options=[
-                {'label': 'Show Unodes for each parameter',
+                {'label': 'Show UNodes for each parameter',
                     'value': 'available_unodes'},
                 {'label': 'Show Ursgal tags',
                     'value': 'show_utags'},
@@ -358,7 +358,7 @@ def update_text(selected_engines, selected_uparams, selected_tags, selected_text
         if 'available_unodes' in selected_text_options:
             text.append(
                 '''
-### Available in unodes:
+### Available in UNodes:
 ''')
             for unode in udict['available_in_unode']:
                 text.append('* {0}'.format(unode))

--- a/docs/uparams_to_dash.py
+++ b/docs/uparams_to_dash.py
@@ -215,6 +215,16 @@ def set_uparams_dropdown(selected_uparams):
 
 
 @app.callback(
+    dash.dependencies.Output('params', 'disabled'),
+    [dash.dependencies.Input('uparams_radio', 'value'), ])
+def set_uparams_dropdown(selected_uparams):
+    if selected_uparams == 'all_uparams':
+        return True
+    if selected_uparams == 'select_uparams':
+        return False
+
+
+@app.callback(
     dash.dependencies.Output('params', 'value'),
     [dash.dependencies.Input('uparams_radio', 'value'), ])
 def set_engines_value(selected_uparams):
@@ -235,6 +245,16 @@ def set_engines_dropdown(selected_engines):
 
 
 @app.callback(
+    dash.dependencies.Output('engine', 'disabled'),
+    [dash.dependencies.Input('engines_radio', 'value'), ])
+def set_engines_dropdown(selected_engines):
+    if selected_engines == 'all_engines':
+        return True
+    if selected_engines == 'select_engines':
+        return False
+
+
+@app.callback(
     dash.dependencies.Output('engine', 'value'),
     [dash.dependencies.Input('engines_radio', 'value'), ])
 def set_engines_value(selected_engines):
@@ -252,6 +272,16 @@ def set_engines_dropdown(selected_tags):
         return [{'disabled': True}]
     if selected_tags == 'select_tags':
         return [{'label': i, 'value': i} for i in sorted(available_tags) if i != '']
+
+
+@app.callback(
+    dash.dependencies.Output('tag', 'disabled'),
+    [dash.dependencies.Input('tags_radio', 'value'), ])
+def set_engines_dropdown(selected_tags):
+    if selected_tags == 'all_tags':
+        return True
+    if selected_tags == 'select_tags':
+        return False
 
 
 @app.callback(
@@ -312,11 +342,11 @@ def update_text(selected_engines, selected_uparams, selected_tags, selected_text
             '''
 ## {0}
 
-> {desc}
+{desc}
 
-> **Default value**: {default_value} \n
-> **type**: {type} \n
-> **triggers rerun**: {rerun} \n
+**Default value**: {default_value} \n
+**type**: {type} \n
+**triggers rerun**: {rerun} \n
 '''.format(
                 ursgal_param,
                 desc=udict['description'].strip(),

--- a/docs/uparams_to_sphinx_docu.py
+++ b/docs/uparams_to_sphinx_docu.py
@@ -70,6 +70,22 @@ if __name__ == '__main__':
 Ursgal Parameters
 *****************
 
+A Dash script has been built in order to make it easier to explore uparams.
+It allows for searching for specific uparams, filtering by UNodes (i.e. engines),
+and filtering by utags. 
+To install Dash, follow the instructions on 
+    | https://dash.plot.ly/
+
+Afterwards, just go to the docs folder and execute the script::
+
+    user@localhost:~/ursgal/docs$ python3.4 uparams_to_sphinx_docu.py
+
+A local server will be created and view the interactive page: 
+    | http://127.0.0.1:8050/
+
+Besides this, all uparams are still listed here as part of the documentation.
+
+
 .. note:: This sphinx source file was **auto-generated** using
     ursgal/docs/uparams_to_sphinx_docu.py, which parses ursgal/ursgal/uparams.py
     Please **do not** modify this file directly, but commit changes to ursgal.uparams.

--- a/docs/uparams_to_sphinx_docu.py
+++ b/docs/uparams_to_sphinx_docu.py
@@ -103,7 +103,7 @@ Ursgal Parameters
             desc = udict['description'].strip(),
             default_value = default_value,
             type = udict.get('uvalue_type', ''),
-            rerun = udict.get('trigger_rerun', 'False')
+            rerun = udict.get('triggers_rerun', 'False')
         ))
 
         uprint('''

--- a/docs/uparams_to_sphinx_docu.py
+++ b/docs/uparams_to_sphinx_docu.py
@@ -113,8 +113,8 @@ Available in unodes
         for unode in udict['available_in_unode']:
             uprint('* {0}'.format( unode ))
         uprint('''
-Ursgal value translations for *{0}*
-""""""""""""""""""""""""""""""""{1}
+Ursgal key translations for *{0}*
+""""""""""""""""""""""""""""""{1}
 '''.format( ursgal_param, '"'*len(ursgal_param)))
         len_longest = determine_longest_string( udict['ukey_translation']  )
         fmt = create_format_string( number_of_columns = 2 )
@@ -138,8 +138,8 @@ Ursgal value translations for *{0}*
         if len( udict['uvalue_translation'] ) == 0:
             continue
         uprint('''
-Ursgal key translations
-"""""""""""""""""""""""
+Ursgal value translations
+"""""""""""""""""""""""""
 ''')
         len_longest = determine_longest_string( udict['uvalue_translation']  )
         fmt = create_format_string(

--- a/example_scripts/quantify_JB_example.py
+++ b/example_scripts/quantify_JB_example.py
@@ -91,7 +91,7 @@ def main():
         )
         all_res.append(fil)
 
-    uc.params['quantitation_evidences'] = all_res
+    uc.params['quantification_evidences'] = all_res
     uc.params['label'] = '15N'
     uc.params['label_percentile'] = [0, 0.99]
     uc.params['evidence_score_field'] = 'combined PEP'

--- a/ursgal/ucontroller.py
+++ b/ursgal/ucontroller.py
@@ -114,11 +114,6 @@ class UController(ursgal.UNode):
         )
         for wrapper_file in glob.glob( wrappers_path_glob ):
             filename = os.path.basename( wrapper_file )
-            # if 'omssa' not in wrapper_file:
-            #     self.print_info('Skipping {0} for dev purpose ...'.format(
-            #         filename
-            #     ))
-            #     continue
             if filename.startswith('__'):
                 continue
             if wrapper_file.startswith('.'):
@@ -725,7 +720,6 @@ class UController(ursgal.UNode):
                 engine=engine_name,
                 multi=True
             )
-
             answer = self.prepare_unode_run(
                 input_files,
                 output_file = output_file_name,
@@ -940,7 +934,8 @@ class UController(ursgal.UNode):
         Returns:
             str: Path of the output file
         '''
-        if 'merge_csvs' in engine:
+        engine_name = self.engine_sanity_check(engine)
+        if 'merge_csvs' in engine_name:
             outfile = self.merge_csvs(
                 input_file,
                 force = force,
@@ -1330,7 +1325,6 @@ class UController(ursgal.UNode):
             )
 
         self.io['output']['finfo'] = self.set_file_info_dict( output_file )
-
         self.take_care_of_params_and_stats( io_mode = 'output')
         # pprint.pprint( self.io )
         # exit(1)
@@ -1473,7 +1467,7 @@ class UController(ursgal.UNode):
 
         # don't build name from history, just take the last file root:
         file_name_blocks.append(
-            self.io['input']['finfo']['file_root']
+            self.io['input']['finfo']['file_root'].strip('.u')
         )
         # add uNodes name as defined in kb
         # if there is no entry called 'output_suffix', the engine/node
@@ -1887,14 +1881,14 @@ class UController(ursgal.UNode):
         """
         The ucontroller quantify function
 
-        Performs a peptide/protein quantification using the specified quantitation engine and
+        Performs a peptide/protein quantification using the specified quantification engine and
         mzML/ident file file. Produces a CSV file with peptide/protein quants in
         the unified Ursgal CSV format.
         see: :ref:`List of available engines<available-engines>`
 
         Keyword Arguments:
             input_file (str): The complete path to the mzML file.
-            engine (str): The name of the quantitation engine which should be
+            engine (str): The name of the quantification engine which should be
                 used, can also be a short version if this name is unambigous.
             force (bool): (Re)do the analysis, even if output file
                 already exists.
@@ -2395,7 +2389,6 @@ class UController(ursgal.UNode):
                 '''
 
         for root_dir, folder_list, file_list in os.walk(root_resource_folder):
-            # print(root,folder)
             engine = os.path.split(root_dir)[-1]
             if engine in self.unodes.keys():
                 # we do not include binaries in the repository

--- a/ursgal/ucore.py
+++ b/ursgal/ucore.py
@@ -62,8 +62,8 @@ def print_current_params( params, old_params=None ):
     print('\tCurrent parameters:')
     print('\t-->>')
     for k, v in sorted( params.items() ):
-        if k in params['skipped_params_for_pprint_output']:
-            continue
+        # if k in params['skipped_params_for_pprint_output']:
+        #     continue
         if old_params is not None and k in old_params.keys():
             if params[ k ] == old_params[k]:
                 skipped_unchanged_params += 1

--- a/ursgal/ukb.py
+++ b/ursgal/ukb.py
@@ -293,7 +293,7 @@ ENGINE_TYPES = {
     'misc_engine'                   : 'execute_misc_engine',
     'meta_engine'                   : 'combine_search_results',
     'protein_database_search_engine': 'search_mgf',
-    'quantitation_engine'           : 'quantify',
+    'quantification_engine'         : 'quantify',
     'spectral_library_search_engine': 'search_mgf',
     '_test'                         : 'execute_misc_engine',
     'validation_engine'             : 'validate',

--- a/ursgal/umapmaster.py
+++ b/ursgal/umapmaster.py
@@ -28,7 +28,7 @@ class UParamMapper( dict ):
     '''
     UParamMapper class offers interface to ursgal.uparams
 
-    Be default, the ursgal.uparams are parsed and the UParamMapper class
+    By default, the ursgal.uparams are parsed and the UParamMapper class
     is set with the ursgal_params dictionary.
     '''
     version = '0.2.0'

--- a/ursgal/unode.py
+++ b/ursgal/unode.py
@@ -1341,14 +1341,14 @@ class UNode(object, metaclass=Meta_UNode):
         #     'cross_link_engine',
         #     False
         # )
-        is_quantitation_engine = self.META_INFO['engine_type'].get(
-            'quantitation_engine',
+        is_quantification_engine = self.META_INFO['engine_type'].get(
+            'quantification_engine',
             False
         )
         map_mods_node_exceptions = [
             'unify_csv'
         ]
-        if is_search_engine or is_quantitation_engine:
+        if is_search_engine or is_quantification_engine:
             self.map_mods()
         for engine_short_name in map_mods_node_exceptions:
             if engine_short_name in self.engine:

--- a/ursgal/uparams.py
+++ b/ursgal/uparams.py
@@ -1050,7 +1050,7 @@ ursgal_params = {
         },
         'default_value'  : 100000,
         'description' : \
-            'sets the number of sequences loaded in as a batch from the '\
+            'Sets the number of sequences loaded in as a batch from the '\
             'database file',
     },
     'batch_size_spectra' : {
@@ -1336,7 +1336,7 @@ ursgal_params = {
         },
         'default_value'  : 1.00794,
         'description' : \
-            'The mass added to the peptide N-terminus bz protein cleavage',
+            'The mass added to the peptide N-terminus by protein cleavage',
     },
     'clip_nterm_m' : {
         'edit_version'   : 1.00,
@@ -1574,7 +1574,7 @@ ursgal_params = {
             'Modifications'
         ],
         'description' : \
-            'List of column headers which are used for counting.'
+            'List of column headers which are used for counting. '
             'The combination of these headers creates the unique countable element.',
     },
     'count_by_file' : {
@@ -1597,7 +1597,7 @@ ursgal_params = {
         'default_value' : True,
         'description' : \
             'the number of unique hits for each identifier '
-            'is given in seperate columns for each raw file '
+            'is given in separate columns for each raw file '
             '(file name as defiened in Spectrum Title)',
     },
     'convert_to_sfinx' : {
@@ -1686,7 +1686,7 @@ ursgal_params = {
         },
         'default_value' : -1,
         'description' : \
-            'Number of used cpus/threads\n'
+            'Number of used cpus/threads\n\n'
             '    -1 : \'max - 1\'\n'
             '    >0 : cpu num',
     },
@@ -1713,8 +1713,8 @@ ursgal_params = {
         'description' : \
             'Cross-link and mono-link masses allowed.\n'\
             'May have more than one of each parameter.\n'\
-            'Format for cross_link is: \n'\
-            '    **[amino acids] [amino acids] [mass mod] [identifier]**\n'\
+            'Format for cross_link is: \n\n'\
+            '**[amino acids] [amino acids] [mass mod] [identifier]**\n\n'\
             'One or more amino acids (uppercase only!!) can be specified for '\
             'each linkage moiety. Use lowercase \'n\' or \'c\' to indicate '\
             'protein N-terminus or C-terminus',
@@ -1745,10 +1745,10 @@ ursgal_params = {
         },
         'default_value' : None,
         'description' : \
-            'Rules are defined as list of lists with three elements:\n'\
-            '1. the column name/csv fieldname,\n'\
-            '2. the rule,\n'\
-            '3.the value which should be compared\n'\
+            'Rules are defined as list of lists with three elements:\n\n'\
+            '1. the column name/csv fieldname,\n\n'\
+            '2. the rule,\n\n'\
+            '3. the value which should be compared\n\n'\
             'e.g.: [\'Is decoy\', \'equals\', \'false\']'
     },
     'database' : {
@@ -1813,8 +1813,7 @@ ursgal_params = {
         },
         'default_value' : None,
         'description' : \
-            'Path to database file containing protein sequences in fasta format\n'\
-            '    \'\' : None',
+            'Path to database file containing protein sequences in fasta format.'
     },
     'database_taxonomy' : {
         'edit_version' : 1.00,
@@ -1870,7 +1869,7 @@ ursgal_params = {
         },
         'default_value' : 'shuffle_peptide',
         'description' : \
-            'Decoy database: Creates a target decoy database based on '\
+            'Decoy database: creates a target decoy database based on '\
             'shuffling of peptides (shuffle_peptide) or complete reversing '\
             'the protein sequence (reverse_protein).',
     },
@@ -2023,10 +2022,8 @@ ursgal_params = {
         'default_value' : None,
         'description' : \
             'Directory containing the model files for PepNovo. If \'None\', '\
-            'it is supposed to be in :\n'\
-            '    resources/<platform>/<architecture>/pepnovo_3_1\n'\
-            '\n'\
-            '    \'\' : None',
+            'it is supposed to be in :\n\n'\
+            'resources/<platform>/<architecture>/pepnovo_3_1'\
     },
     'engine_internal_decoy_generation' : {
         'edit_version' : 1.00,

--- a/ursgal/uparams.py
+++ b/ursgal/uparams.py
@@ -15,7 +15,7 @@ ursgal_params = {
             'pyqms_style_1': 'pyqms_verbosity'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -39,7 +39,8 @@ ursgal_params = {
             'pyqms_style_1' : 'PECENTILE_FORMAT_STRING'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'label',
         ],
         'uvalue_translation': {
         },
@@ -60,13 +61,13 @@ ursgal_params = {
             'f-point': 1e-02
         },
         'default_value': 1e-3,
-        'description': """ Set minmal abundance for elements used when building Isotopoluge Library """,
+        'description': """ Set minmal abundance for elements used when building isotopologue library """,
         'triggers_rerun': True,
         'ukey_translation': {
             'pyqms_style_1' : 'ELEMENT_MIN_ABUNDANCE'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -93,7 +94,7 @@ ursgal_params = {
             'pyqms_style_1' : 'MIN_REL_PEAK_INTENSITY_FOR_MATCHING'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -120,7 +121,7 @@ ursgal_params = {
             'pyqms_style_1' : 'REQUIRED_PERCENTILE_PEAK_OVERLAP'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -146,7 +147,8 @@ ursgal_params = {
             'pyqms_style_1': 'MININUM_NUMBER_OF_MATCHES_ISOTOPOLOGUES'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'accuracy'
         ],
         'uvalue_translation': {
         },
@@ -173,7 +175,8 @@ ursgal_params = {
             'pyqms_style_1': 'INTENSITY_TRANSFORMATION_FACTOR'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'conversion'
         ],
         'uvalue_translation': {
         },
@@ -200,7 +203,8 @@ ursgal_params = {
             'pyqms_style_1': 'UPPER_MZ_LIMIT'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'spectrum',
         ],
         'uvalue_translation': {
         },
@@ -227,7 +231,8 @@ ursgal_params = {
             'pyqms_style_1': 'LOWER_MZ_LIMIT'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'spectrum',
         ],
         'uvalue_translation': {
         },
@@ -254,7 +259,8 @@ ursgal_params = {
             'pyqms_style_1': 'MZ_TRANSFORMATION_FACTOR'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'conversion',
         ],
         'uvalue_translation': {
         },
@@ -276,13 +282,14 @@ ursgal_params = {
 
         },
         'default_value': 5e-6,
-        'description': """ rel mz Error """,
+        'description': """ relative mz error """,
         'triggers_rerun': True,
         'ukey_translation': {
             'pyqms_style_1': 'REL_MZ_RANGE'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'accuracy',
         ],
         'uvalue_translation': {
         },
@@ -309,7 +316,8 @@ ursgal_params = {
             'pyqms_style_1': 'REL_I_RANGE'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'accuracy'
         ],
         'uvalue_translation': {
         },
@@ -336,7 +344,8 @@ ursgal_params = {
             'pyqms_style_1': 'INTERNAL_PRECISION'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'conversion'
         ],
         'uvalue_translation': {
         },
@@ -362,7 +371,7 @@ ursgal_params = {
             'pyqms_style_1': 'MAX_MOLECULES_PER_MATCH_BIN'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -389,7 +398,8 @@ ursgal_params = {
             'pyqms_style_1': 'SILAC_AAS_LOCKED_IN_EXPERIMENT'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'label',
         ],
         'uvalue_translation': {
         },
@@ -415,7 +425,7 @@ ursgal_params = {
             'pyqms_style_1': 'BUILD_RESULT_INDEX'
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -496,7 +506,7 @@ ursgal_params = {
     #         'pyqms_style_1': 'COLORS'
     #     },
     #     'utag': [
-    #         'quantitation',
+    #         'quantification',
     #     ],
     #     'uvalue_translation': {
     #     },
@@ -508,13 +518,14 @@ ursgal_params = {
             'pyqms_1_0_0',
         ],
         'default_value': "PEP",
-        'description':  ''' field which is used for scoring in peptide_amounts_0_0_1 ''',
+        'description':  ''' Field which is used for scoring in pyqms_1_0_0 ''',
         'triggers_rerun': True,
         'ukey_translation': {
             'pyqms_style_1' : 'evidence_score_field'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'scoring',
         ],
         'uvalue_option': {
             'none_val': None,
@@ -524,7 +535,7 @@ ursgal_params = {
         },
         'uvalue_type': 'str',
     },
-    'quantitation_evidences': {
+    'quantification_evidences': {
         'edit_version' : 1.00,
         'available_in_unode': [
             'pyqms_1_0_0',
@@ -544,7 +555,7 @@ ursgal_params = {
             'custom_type': {}
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -553,7 +564,6 @@ ursgal_params = {
     'm_score_cutoff': {
         'edit_version' : 1.00,
         'available_in_unode': [
-            # 'protein_amounts_0_0_5',
             'pyqms_1_0_0'
         ],
         'uvalue_option': {
@@ -569,11 +579,11 @@ ursgal_params = {
         'description':  ''' minimum required pyQms m_score for a quant event to be evaluated ''',
         'triggers_rerun': True,
         'ukey_translation': {
-            # 'protein_amounts_style_1': 'm_cutoff',
-            'pyqms_style_1'           : 'm_score_cutoff'
+            'pyqms_style_1': 'm_score_cutoff'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'scoring',
         ],
         'uvalue_translation': {
         },
@@ -603,7 +613,7 @@ ursgal_params = {
             'pyqms_style_1': 'molecules',
         },
         'utag': [
-            'quantitation',
+            'quantification',
         ],
         'uvalue_translation': {
         },
@@ -621,7 +631,8 @@ ursgal_params = {
             'pyqms_style_1': 'mz_score_percentile'
         },
         'utag': [
-            'quantitation',
+            'quantification',
+            'scoring',
         ],
         'uvalue_option': {
             'max': 1.0,
@@ -657,7 +668,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'ms_level',
         },
         'utag': [
-            'Spectrum'
+            'spectrum'
         ],
         'uvalue_translation': {
         },
@@ -676,6 +687,7 @@ ursgal_params = {
         },
         'utag' : [
             'label',
+            'quantification'
         ],
         'uvalue_option' : {
             'none_val' : [],
@@ -725,7 +737,8 @@ ursgal_params = {
             'pyqms_style_1' : 'FIXED_LABEL_ISOTOPE_ENRICHMENT_LEVELS',
         },
         'utag' : [
-            'quantitation',
+            'quantification',
+            'label',
         ],
         'uvalue_option' : {
             'item_titles':  {
@@ -782,7 +795,8 @@ ursgal_params = {
             'pyqms_style_1' : 'trivial_names'
         },
         'utag' : [
-            'quantitation',
+            'quantification',
+            'output',
         ],
         'uvalue_option' : {
             'custom_type' : {
@@ -806,7 +820,6 @@ ursgal_params = {
     'rt_border_tolerance' : {
         'edit_version' : 1.00,
         'available_in_unode' : [
-            # 'protein_amounts_0_0_5',
             'pyqms_1_0_0',
         ],
         'default_value' : 1,
@@ -814,10 +827,10 @@ ursgal_params = {
         'triggers_rerun' : True,
         'ukey_translation' : {
             'pyqms_style_1' : 'rt_border_tolerance',
-            # 'protein_amounts_style_1' : 'rt_border_tolerance'
         },
         'utag' : [
-            'quantitation',
+            'quantification',
+            'chromatography'
         ],
         'uvalue_option' : {
             'f-point' : 0.01,
@@ -998,8 +1011,7 @@ ursgal_params = {
             'pipi_style_1'    : 'base_mz',
         },
         'utag' : [
-            'fragment',
-            'precursor',
+            'conversion'
         ],
         'uvalue_translation' : {
         },
@@ -1290,6 +1302,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'cleavage',
         ],
         'uvalue_translation' : {
         },
@@ -1322,6 +1335,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'cleavage'
         ],
         'uvalue_translation' : {
         },
@@ -1344,7 +1358,7 @@ ursgal_params = {
             'msfragger_20170103',
         ],
         'default_value' : False,
-        'description' :  ''' Specifies the trimming of a protein N-terminal methionine as a variable modification (0 or 1) ''',
+        'description' :  ''' Specifies the trimming of a protein N-terminal methionine as a variable modification ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
             'msfragger_style_1' : 'clip_nTerm_M',
@@ -1428,7 +1442,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'compomics_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_option' : {
             'none_val'      : '',
@@ -1449,6 +1463,7 @@ ursgal_params = {
         },
         'utag' : [
             'file_handling',
+            'conversion'
         ],
         'uvalue_translation' : {
             'ucontroller_style_1':{
@@ -1552,7 +1567,7 @@ ursgal_params = {
             'csv2counted_results_style_1' : 'count_column_names',
         },
         'utag' : [
-            'convertion',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -1700,7 +1715,7 @@ ursgal_params = {
             'kojak_style_1' : 'cross_link_definition',
         },
         'utag' : [
-            'cross-linking',
+            'cross_linking',
         ],
         'uvalue_translation' : {
         },
@@ -1800,7 +1815,6 @@ ursgal_params = {
         },
         'utag' : [
             'database',
-            'input',
             'input_files',
         ],
         'uvalue_translation' : {
@@ -1982,6 +1996,7 @@ ursgal_params = {
         },
         'utag' : [
             'model',
+            'denovo'
         ],
         'uvalue_translation' : {
             'pepnovo_style_1' : {
@@ -2010,7 +2025,7 @@ ursgal_params = {
         },
         'utag' : [
             'model',
-            'input_dir',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -2054,7 +2069,6 @@ ursgal_params = {
         },
         'utag' : [
             'database',
-            'input',
         ],
         'uvalue_translation' : {
             'msamanda_style_1' : {
@@ -2154,6 +2168,7 @@ ursgal_params = {
         'utag' : [
             'database',
             'protein',
+            'cleavage',
         ],
         'uvalue_translation' : {
             'generate_target_decoy_style_1' : {
@@ -2481,7 +2496,6 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
-            'statistics',
             'validation',
         ],
         'uvalue_translation' : {
@@ -2544,7 +2558,7 @@ ursgal_params = {
             'novor_style_1' : 'forbiddenResidues',
         },
         'utag' : [
-            'de_novo',
+            'denovo',
         ],
         'uvalue_translation' : {
         },
@@ -2662,6 +2676,7 @@ ursgal_params = {
         },
         'utag' : [
             'fragment',
+            'accuracy'
         ],
         'uvalue_translation' : {
         },
@@ -2717,6 +2732,7 @@ ursgal_params = {
         },
         'utag' : [
             'fragment',
+            'accuracy',
         ],
         'uvalue_translation' : {
             'msamanda_style_1' : {
@@ -2832,6 +2848,8 @@ ursgal_params = {
         },
         'utag' : [
             'instrument',
+            'fragment',
+            'model',
         ],
         'uvalue_translation' : {
             'msgfplus_style_1' : {
@@ -2853,8 +2871,8 @@ ursgal_params = {
         'default_value' : 'hcd',
         'description' : \
             'Used fragmentation method, e.g. collision-induced dissociation '\
-            '(CID), electron-capture dissociation (ECD), electron-transfer '\
-            'dissociation (ETD), Higher-energy C-trap dissociation (HCD)',
+            '(cid), electron-capture dissociation (ecd), electron-transfer '\
+            'dissociation (etd), Higher-energy C-trap dissociation (hcd)',
     },
     'frag_min_mz' : {
         'edit_version' : 1.00,
@@ -2899,6 +2917,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -2925,6 +2944,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -2949,6 +2969,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -2999,6 +3020,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -3026,6 +3048,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -3120,7 +3143,7 @@ ursgal_params = {
             'pipi_style_1'             : 'header_translations',
         },
         'utag' : [
-            'Conversion',
+            'conversion',
         ],
         'uvalue_translation' : {
             'kojak_percolator_style_1' : {
@@ -3260,7 +3283,8 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_annotation_field_name',
         },
         'utag' : [
-            '',
+            'visualization',
+            'output',
         ],
         'uvalue_translation' : {
         },
@@ -3283,7 +3307,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_box_style',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3306,7 +3330,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_color_gradient',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3329,7 +3353,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_column_order',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3362,7 +3386,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_error_suffix',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3385,7 +3409,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_identifier_field_name',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3408,7 +3432,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_max_value',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3434,7 +3458,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_min_value',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3460,7 +3484,7 @@ ursgal_params = {
             'heatmap_style_1' : 'heatmap_value_suffix',
         },
         'utag' : [
-            '',
+            'visualization',
         ],
         'uvalue_translation' : {
         },
@@ -3507,6 +3531,7 @@ ursgal_params = {
         },
         'utag' : [
             'download',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -3563,6 +3588,7 @@ ursgal_params = {
         },
         'utag' : [
             'instrument',
+            'model',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -3615,7 +3641,7 @@ ursgal_params = {
             'csv2counted_results_style_1' : 'identifier_column_names',
         },
         'utag' : [
-            'convertion',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -3703,6 +3729,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'cleavage',
         ],
         'uvalue_translation' : {
         },
@@ -3727,7 +3754,6 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
-            'statistics',
             'validation',
         ],
         'uvalue_translation' : {
@@ -3779,6 +3805,7 @@ ursgal_params = {
         },
         'utag' : [
             'spectrum',
+            'accuracy'
         ],
         'uvalue_translation' : {
         },
@@ -3794,7 +3821,7 @@ ursgal_params = {
         'description' : \
             'MS1 resolution',
     },
-    'ms2_is_centroid' : {
+    'ms2_is_centroided' : {
         'edit_version' : 1.00,
         'available_in_unode' : [
             'kojak_1_5_3',
@@ -3804,7 +3831,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_MS2_centroid',
         },
         'utag' : [
-            'cross-linking',
+            'spectrum',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -3830,6 +3857,7 @@ ursgal_params = {
         },
         'utag' : [
             'spectrum',
+            'accuracy'
         ],
         'uvalue_translation' : {
         },
@@ -3855,7 +3883,7 @@ ursgal_params = {
             'csv2counted_results_style_1' : 'keep_column_names',
         },
         'utag' : [
-            'convertion',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -3892,7 +3920,8 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_diff_mods_on_xl',
         },
         'utag' : [
-            'cross-linking',
+            'cross_linking',
+            'modifications',
         ],
         'uvalue_translation' : {
         },
@@ -3919,7 +3948,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_enrichment',
         },
         'utag' : [
-            'cross-linking',
+            'cross_linking',
         ],
         'uvalue_translation' : {
         },
@@ -3947,7 +3976,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_export_pepXML',
         },
         'utag' : [
-            'cross-linking',
+            'output',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -3972,7 +4001,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_export_percolator',
         },
         'utag' : [
-            'cross-linking',
+            'output',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -3997,7 +4026,8 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_fragment_bin_offset',
         },
         'utag' : [
-            'cross-linking',
+            'accuracy',
+            'hardware_resources'
         ],
         'uvalue_translation' : {
         },
@@ -4028,7 +4058,8 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_fragment_bin_size',
         },
         'utag' : [
-            'cross-linking',
+            'accuracy',
+            'hardware_resources'
         ],
         'uvalue_translation' : {
         },
@@ -4059,7 +4090,8 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_mono_links_on_xl',
         },
         'utag' : [
-            'cross-linking',
+            'cross_linking',
+            'modifications'
         ],
         'uvalue_translation' : {
         },
@@ -4086,7 +4118,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_percolator_version',
         },
         'utag' : [
-            'cross-linking',
+            'node_versions',
         ],
         'uvalue_translation' : {
         },
@@ -4109,7 +4141,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_prefer_precursor_pred',
         },
         'utag' : [
-            'cross-linking',
+            'precursor',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -4131,9 +4163,9 @@ ursgal_params = {
         'default_value' : 'supplement',
         'description' : \
             'prefer precursor mono mass predicted by instrument software.\n'\
-            'Available values:\n'\
-            '    ignore_previous: previous predictions are ignored\n'\
-            '    only_previous: only previous predictions are used\n'\
+            'Available values:\n\n'\
+            '    ignore_previous: previous predictions are ignored\n\n'\
+            '    only_previous: only previous predictions are used\n\n'\
             '    supplement: predictions are supplemented with additional analysis',
     },
     'kojak_spectrum_processing' : {
@@ -4146,7 +4178,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_spectrum_processing',
         },
         'utag' : [
-            'cross-linking',
+            'spectrum',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -4171,7 +4203,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_top_count',
         },
         'utag' : [
-            'cross-linking',
+            'scoring',
         ],
         'uvalue_translation' : {
         },
@@ -4198,7 +4230,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_truncate_prot_names',
         },
         'utag' : [
-            'cross-linking',
+            'output',
         ],
         'uvalue_translation' : {
         },
@@ -4224,7 +4256,7 @@ ursgal_params = {
             'kojak_style_1' : 'kojak_turbo_button',
         },
         'utag' : [
-            'cross-linking',
+            'hardware_resources',
         ],
         'uvalue_translation' : {
             'kojak_style_1' : {
@@ -4309,8 +4341,9 @@ ursgal_params = {
             'pyqms_style_1'    : 'MACHINE_OFFSET_IN_PPM'
         },
         'utag' : [
-            'converter',
+            'conversion',
             'instrument',
+            'accuracy',
         ],
         'uvalue_translation' : {
         },
@@ -4350,7 +4383,7 @@ ursgal_params = {
             'msfragger_style_1' : 'use_topN_peaks'
         },
         'utag' : [
-            'MS2',
+            'spectrum',
             'fragment',
         ],
         'uvalue_translation' : {
@@ -4409,6 +4442,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'cleavage'
         ],
         'uvalue_translation' : {
         },
@@ -4748,6 +4782,7 @@ ursgal_params = {
         },
         'utag' : [
             'peptide',
+            'cleavage',
         ],
         'uvalue_translation' : {
         },
@@ -4779,6 +4814,7 @@ ursgal_params = {
         },
         'utag' : [
             'peptide',
+            'modifications'
         ],
         'uvalue_translation' : {
         },
@@ -4830,7 +4866,6 @@ ursgal_params = {
             'xtandem_style_1'  : 'spectrum, path',
         },
         'utag' : [
-            'input',
             'input_files',
         ],
         'uvalue_translation' : {
@@ -4936,6 +4971,7 @@ ursgal_params = {
         },
         'utag' : [
             'peptide',
+            'cleavage'
         ],
         'uvalue_translation' : {
         },
@@ -5102,6 +5138,8 @@ ursgal_params = {
             'moda_style_1' : 'HighResolution',
         },
         'utag' : [
+            'fragment',
+            'accuracy',
         ],
         'uvalue_translation' : {
             'moda_style_1' : {
@@ -5128,6 +5166,8 @@ ursgal_params = {
             'moda_style_1' : 'Protocol',
         },
         'utag' : [
+            'scoring',
+            'label'
         ],
         'uvalue_translation' : {
             'moda_style_1' : {
@@ -5276,7 +5316,7 @@ ursgal_params = {
             'kojak_style_1' : 'mono_link_definition',
         },
         'utag' : [
-            'cross-linking',
+            'cross_linking',
         ],
         'uvalue_translation' : {
         },
@@ -5295,108 +5335,6 @@ ursgal_params = {
             'each linkage moiety. Use lowercase \'n\' or \'c\' to indicate '\
             'protein N-terminus or C-terminus',
     },
-    'ms1_centroided' : {
-        'edit_version' : 1.00,
-        'available_in_unode' : [
-            'kojak_1_5_3',
-        ],
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'kojak_style_1' : 'kojak_MS1_centroid',
-        },
-        'utag' : [
-            'cross-linking',
-        ],
-        'uvalue_translation' : {
-            'kojak_style_1' : {
-                False : 0,
-                True  : 1,
-            },
-        },
-        'uvalue_type' : 'bool',
-        'uvalue_option' : {
-        },
-        'default_value' : False,
-        'description' : \
-            'MS1 data are centroided: True or False',
-    },
-    'ms1_resolution' : {
-        'edit_version' : 1.00,
-        'available_in_unode' : [
-            'kojak_1_5_3',
-        ],
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'kojak_style_1' : 'kojak_MS1_resolution',
-        },
-        'utag' : [
-            'cross-linking',
-        ],
-        'uvalue_translation' : {
-        },
-        'uvalue_type' : 'int',
-        'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 100000000,
-            'min'       : 0,
-            'updownval' : 1,
-            'unit'      : ''
-        },
-        'default_value' : 30000,
-        'description' : \
-            'MS1 resolution',
-    },
-    'ms2_centroided' : {
-        'edit_version' : 1.00,
-        'available_in_unode' : [
-            'kojak_1_5_3',
-        ],
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'kojak_style_1' : 'kojak_MS2_centroid',
-        },
-        'utag' : [
-            'cross-linking',
-        ],
-        'uvalue_translation' : {
-            'kojak_style_1' : {
-                False : 0,
-                True  : 1,
-            },
-        },
-        'uvalue_type' : 'bool',
-        'uvalue_option' : {
-        },
-        'default_value' : True,
-        'description' : \
-            'MS2 data are centroided: True or False',
-    },
-    'ms2_resolution' : {
-        'edit_version' : 1.00,
-        'available_in_unode' : [
-            'kojak_1_5_3',
-        ],
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'kojak_style_1' : 'kojak_MS2_resolution',
-        },
-        'utag' : [
-            'cross-linking',
-        ],
-        'uvalue_translation' : {
-        },
-        'uvalue_type' : 'int',
-        'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 100000000,
-            'min'       : 0,
-            'updownval' : 1,
-            'unit'      : ''
-        },
-        'default_value' : 25000,
-        'description' : \
-            'MS2 resolution',
-    },
     'msgfplus_protocol_id' : {
         'edit_version' : 1.01,
         'available_in_unode' : [
@@ -5409,6 +5347,8 @@ ursgal_params = {
             'msgfplus_style_1' : '-protocol',
         },
         'utag' : [
+            'scoring',
+            'label'
         ],
         'uvalue_translation' : {
             'msgfplus_style_1' : {
@@ -5441,6 +5381,8 @@ ursgal_params = {
             'msfragger_style_1' : 'output_max_expect',
         },
         'utag' : [
+            'output',
+            'scoring'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -5465,6 +5407,8 @@ ursgal_params = {
             'msfragger_style_1' : 'track_zero_topN',
         },
         'utag' : [
+            'output',
+            'scoring'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -5489,6 +5433,7 @@ ursgal_params = {
             'msfragger_style_1' : 'zero_bin_accept_expect',
         },
         'utag' : [
+            'scoring'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -5514,6 +5459,7 @@ ursgal_params = {
             'msfragger_style_1' : 'zero_bin_mult_expect',
         },
         'utag' : [
+            'scoring'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -5533,12 +5479,14 @@ ursgal_params = {
             'msfragger_20170103',
         ],
         'default_value' : False,
-        'description' :  ''' Inserts complementary ions corresponding to the top N most intense fragments in each experimental spectra. Useful for recovery of modified peptides near C-terminal in open search. Should be set to 0 (disabled) otherwise. ''',
+        'description' :  ''' Inserts complementary ions corresponding to the top N most intense fragments in each experimental spectrum. Useful for recovery of modified peptides near C-terminal in open search. Should be set to 0 (disabled) otherwise. ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
             'msfragger_style_1' : 'add_topN_complementary',
         },
         'utag' : [
+            'scoring',
+            'spectrum'
         ],
         'uvalue_option' : {
         },
@@ -5562,6 +5510,8 @@ ursgal_params = {
             'msfragger_style_1' : 'min_fragments_modelling',
         },
         'utag' : [
+            'spectrum',
+            'scoring'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -5586,7 +5536,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'msgfplus_mzid_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_option' : {
             'none_val'     : '',
@@ -5612,6 +5562,7 @@ ursgal_params = {
             'myrimatch_style_1' : 'ClassSizeMultiplier',
         },
         'utag' : [
+            'scoring'
         ],
         'uvalue_translation' : {
         },
@@ -5638,6 +5589,7 @@ ursgal_params = {
             'myrimatch_style_1' : 'NumIntensityClasses',
         },
         'utag' : [
+            'scoring'
         ],
         'uvalue_translation' : {
         },
@@ -5664,6 +5616,8 @@ ursgal_params = {
             'myrimatch_style_1' : 'NumMzFidelityClasses',
         },
         'utag' : [
+            'spectrum',
+            'scoring'
         ],
         'uvalue_translation' : {
         },
@@ -5690,6 +5644,7 @@ ursgal_params = {
             'myrimatch_style_1' : 'ProteinSamplingTime',
         },
         'utag' : [
+            'chromatography'
         ],
         'uvalue_translation' : {
         },
@@ -5716,6 +5671,8 @@ ursgal_params = {
             'myrimatch_style_1' : 'UseSmartPlusThreeModel',
         },
         'utag' : [
+            'model',
+            'scoring'
         ],
         'uvalue_translation' : {
             'myrimatch_style_1' : {
@@ -5741,6 +5698,7 @@ ursgal_params = {
             'myrimatch_style_1' : 'TicCutoffPercentage',
         },
         'utag' : [
+            'spectrum'
         ],
         'uvalue_translation' : {
         },
@@ -5770,6 +5728,7 @@ ursgal_params = {
         },
         'utag' : [
             'output',
+            'file_handling'
         ],
         'uvalue_translation' : {
             'mzidentml_style_1' : {
@@ -5794,7 +5753,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'mzidentml_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_translation' : {
         },
@@ -5851,6 +5810,7 @@ ursgal_params = {
             'mzidentml_style_1' : 'mzidentml_function',
         },
         'utag' : [
+            'output'
         ],
         'uvalue_translation' : {
         },
@@ -5940,7 +5900,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'mzml2mgf_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_translation' : {
         },
@@ -6143,7 +6103,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'number_of_i_decimals',
         },
         'utag' : [
-            'converter',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -6217,7 +6177,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'number_of_mz_decimals',
         },
         'utag' : [
-            'converter',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -6915,7 +6875,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'peptide_mapper_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_option' : {
             'none_val'     : None,
@@ -7099,6 +7059,7 @@ ursgal_params = {
         },
         'utag' : [
             'precursor',
+            'accuracy'
         ],
         'uvalue_translation' : {
         },
@@ -7164,6 +7125,7 @@ ursgal_params = {
         },
         'utag' : [
             'precursor',
+            'accuracy'
         ],
         'uvalue_translation' : {
         },
@@ -7224,6 +7186,7 @@ ursgal_params = {
         },
         'utag' : [
             'precursor',
+            'accuracy'
         ],
         'uvalue_translation' : {
             'msamanda_style_1' : {
@@ -7497,6 +7460,8 @@ ursgal_params = {
             'msfragger_style_1' : 'precursor_true_tolerance',
         },
         'utag' : [
+            'precursor',
+            'accuracy'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -7521,6 +7486,8 @@ ursgal_params = {
             'msfragger_style_1' : 'precursor_true_units',
         },
         'utag' : [
+            'precursor',
+            'accuracy'
         ],
         'uvalue_option' : {
             'multiple_line' : False,
@@ -7702,7 +7669,7 @@ ursgal_params = {
             'qvality_style_1' : '-v',
         },
         'utag' : [
-            'validation',
+            'output',
         ],
         'uvalue_translation' : {
             'qvality_style_1' : {
@@ -7758,7 +7725,7 @@ ursgal_params = {
             'sanitize_csv_style_1' : 'remove_redundant_psms',
         },
         'utag' : [
-            'validation',
+            'output'
         ],
         'uvalue_translation' : {
         },
@@ -7804,6 +7771,7 @@ ursgal_params = {
         },
         'utag' : [
             'modifications',
+            'conversion'
         ],
         'uvalue_translation' : {
         },
@@ -7832,6 +7800,7 @@ ursgal_params = {
         },
         'utag' : [
             'file_handling',
+            'chromatography'
         ],
         'uvalue_translation' : {
         },
@@ -7854,7 +7823,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'scan_exclusion_list',
         },
         'utag' : [
-            'converter',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -7890,7 +7859,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'scan_inclusion_list',
         },
         'utag' : [
-            'converter',
+            'conversion',
         ],
         'uvalue_translation' : {
         },
@@ -7925,7 +7894,7 @@ ursgal_params = {
             'mzml2mgf_style_1' : 'scan_skip_modulo_step',
         },
         'utag' : [
-            'converter',
+            'conversion',
         ],
         'uvalue_translation' : {
             'mzml2mgf_style_1' : {
@@ -8048,7 +8017,7 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
-            'fragmentation'
+            'fragment'
         ],
         'uvalue_translation' : {
         },
@@ -8604,6 +8573,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'modifications'
         ],
         'uvalue_translation' : {
             'xtandem_style_1' : {
@@ -8660,6 +8630,7 @@ ursgal_params = {
         },
         'utag' : [
             'protein',
+            'cleavage'
         ],
         'uvalue_translation' : {
             'moda_style_1' : {
@@ -8704,6 +8675,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'show_unodes_in_development',
         },
         'utag' : [
+            'internal'
         ],
         'uvalue_translation' : {
         },
@@ -8762,6 +8734,7 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
+            'conversion'
         ],
         'uvalue_option' : {
             'none_val'  : None,
@@ -8784,6 +8757,7 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
+            'conversion'
         ],
         'uvalue_option' : {
             'select_type' : 'radio_button',
@@ -8806,7 +8780,6 @@ ursgal_params = {
         },
         'utag' : [
             'scoring',
-            'statistics',
             'validation',
         ],
         'uvalue_translation' : {
@@ -8834,7 +8807,7 @@ ursgal_params = {
             '_test_node_style_1' : 'test_param1',
         },
         'utag' : [
-            'debugging',
+            'internal',
             'testing',
         ],
         'uvalue_translation' : {
@@ -8866,7 +8839,7 @@ ursgal_params = {
             '_test_node_style_1' : 'test_param2',
         },
         'utag' : [
-            'debugging',
+            'internal',
             'testing',
         ],
         'uvalue_translation' : {
@@ -8899,6 +8872,7 @@ ursgal_params = {
         },
         'utag' : [
             'validation',
+            'scoring'
         ],
         'uvalue_translation' : {
         },
@@ -8919,7 +8893,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'unify_csv_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_translation' : {
         },
@@ -8942,7 +8916,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'ursgal_resource_url',
         },
         'utag' : [
-            'installation',
+            'download',
         ],
         'uvalue_translation' : {
         },
@@ -8995,7 +8969,7 @@ ursgal_params = {
             'xtandem_style_1' : 'refine',
         },
         'utag' : [
-            'refinement',
+            'scoring',
         ],
         'uvalue_translation' : {
             'xtandem_style_1' : {
@@ -9025,6 +8999,7 @@ ursgal_params = {
         },
         'utag' : [
             'precursor',
+            'spectrum'
         ],
         'uvalue_translation' : {
             'msfragger_style_1' : {
@@ -9052,6 +9027,7 @@ ursgal_params = {
         },
         'utag' : [
             'precursor',
+            'spectrum'
         ],
         'uvalue_translation' : {
             'moda_style_1' : {
@@ -9076,7 +9052,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'validated_ident_csv_suffix',
         },
         'utag' : [
-            'file_extension',
+            'file_handling',
         ],
         'uvalue_translation' : {
         },
@@ -9192,6 +9168,7 @@ ursgal_params = {
         },
         'utag' : [
             'validation',
+            'scoring'
         ],
         'uvalue_translation' : {
             'add_estimated_fdr_style_1' : {
@@ -9755,8 +9732,8 @@ ursgal_params = {
             'combine_pep_style_1' : 'window_size',
         },
         'utag' : [
-            'combining_search_results',
-            'statistics',
+            'validation',
+            'scoring',
         ],
         'uvalue_translation' : {
         },
@@ -9837,7 +9814,7 @@ ursgal_params = {
             'ucontroller_style_1' : 'xtandem_converter_version',
         },
         'utag' : [
-            'converter_version',
+            'node_versions',
         ],
         'uvalue_option' : {
             'none_val'     : '',

--- a/ursgal/uparams.py
+++ b/ursgal/uparams.py
@@ -958,80 +958,29 @@ ursgal_params = {
             'best and secondbest PSM is not above the threshold, i.e. if '\
             'there are conflicting PSMs with similar scores.',
     },
-    'add_cterm_peptide' : {
-        'edit_version'   : 1.00,
-        'available_in_unode' : [
-            'msfragger_20170103',
-        ],
-        'default_value' : 0.0,
-        'description' :  ''' Statically add mass in Da to C-terminal of peptide ''',
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'msfragger_style_1' : 'add_Cterm_peptide',
-        },
-        'utag' : [
-            'validation',
-        ],
-        'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 10000,
-            'min'       : 0,
-            'f-point'   : 1e-02,
-            'updownval' : 1,
-            'unit'      : ''
-        },
-        'uvalue_translation' : {
-        },
-        'uvalue_type' : "float",
-    },
-    'add_nterm_peptide' : {
-        'edit_version'   : 1.00,
-        'available_in_unode' : [
-            'msfragger_20170103',
-        ],
-        'default_value' : 0.0,
-        'description' :  ''' Statically add mass in Da to N-terminal of peptide ''',
-        'triggers_rerun' : True,
-        'ukey_translation' : {
-            'msfragger_style_1' : 'add_Nterm_peptide',
-        },
-        'utag' : [
-        ],
-        'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 10000,
-            'min'       : 0,
-            'f-point'   : 1e-02,
-            'updownval' : 1,
-            'unit'      : ''
-        },
-        'uvalue_translation' : {
-        },
-        'uvalue_type' : 'float',
-    },
     'allow_multiple_variable_mods_on_residue' : {
         'edit_version'   : 1.00,
         'available_in_unode' : [
             'msfragger_20170103',
         ],
-        'default_value' : 1,
-        'description' :  ''' static mods are not considered ''',
+        'default_value' : True,
+        'description' :  ''' Static mods are not considered ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
             'msfragger_style_1' : 'allow_multiple_variable_mods_on_residue',
         },
         'utag' : [
+            'modifications'
         ],
         'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 1,
-            'min'       : 0,
-            'updownval' : 1,
-            'unit'      : ''
         },
         'uvalue_translation' : {
+            'msfragger_style_1' : {
+                False : 0,
+                True : 1,
+            }
         },
-        'uvalue_type' : "int",
+        'uvalue_type' : "bool",
     },
     'base_mz' : {
         'edit_version'   : 1.00,
@@ -1394,7 +1343,7 @@ ursgal_params = {
         'available_in_unode' : [
             'msfragger_20170103',
         ],
-        'default_value' : 0,
+        'default_value' : False,
         'description' :  ''' Specifies the trimming of a protein N-terminal methionine as a variable modification (0 or 1) ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
@@ -1403,15 +1352,14 @@ ursgal_params = {
         'utag' : [
         ],
         'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 1,
-            'min'       : 0,
-            'updownval' : 1,
-            'unit'      : ''
         },
         'uvalue_translation' : {
+            'msfragger_style_1' : {
+                False : 0,
+                True : 1,
+            }
         },
-        'uvalue_type' : "int",
+        'uvalue_type' : "bool",
     },
     'compensate_small_fasta' : {
         'edit_version'   : 1.00,
@@ -5289,8 +5237,8 @@ ursgal_params = {
         'description' : \
             'Modifications are given as a list of strings, each representing '\
             'the modification of one amino acid. The string consists of four '\
-            'informations seperated by comma: \n'\
-            '    \'amino acid, type, position, unimod name or id\'\n'\
+            'informations seperated by comma: \n\n'\
+            '    \'amino acid, type, position, unimod name or id\'\n\n'\
             '    amino acid  : specify the modified amino acid as a single '\
             'letter, use \'*\' if the amino acid is variable\n'\
             '    type        : specify if it is a fixed (fix) or potential '\
@@ -5301,7 +5249,7 @@ ursgal_params = {
             '    unimod name or id: specify the unimod PSI-MS Name '\
             'or unimod Accession # (see unimod.org)\n'\
             '\n'\
-            'Examples:\n'\
+            'Examples:\n\n'\
             '    [ \'M,opt,any,Oxidation\' ] - potential oxidation of Met at '\
             'any position within a peptide\n'\
             '    [ \'*,opt,Prot-N-term,Acetyl\' ] - potential acetylation of '\
@@ -5311,14 +5259,14 @@ ursgal_params = {
             '    [ \'C,fix,any,Carbamidomethyl\', \'N,opt,any,Deamidated\', '\
             '\'Q,opt,any,Deamidated\' ] - fixed carbamidomethylation of Cys '\
             'and potential deamidation of Asn and/or Gln at any position '\
-            'within a peptide\n'\
+            'within a peptide\n\n'\
             'Additionally, userdefined modifications can be given and are '\
             'written to a userdefined_unimod.xml in ursgal/kb/ext. '\
             'Userdefined modifications need to have a unique name instead of '\
             'the unimod name the chemical composition needs to be given as a '\
             'Hill notation on the fifth position in the string\n'\
             '\n'\
-            'Example:\n'\
+            'Example:\n\n'\
             '[ \'S,opt,any,New_mod,C2H5N1O3\' ]',
     },
     'mono_link_definition' : {
@@ -5537,7 +5485,7 @@ ursgal_params = {
         'available_in_unode' : [
             'msfragger_20170103',
         ],
-        'default_value' : 0,
+        'default_value' : 0.0,
         'description' :  ''' Ranks a zero-bin hit above all non-zero-bin hit if it has expectation less than this value. ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
@@ -5547,21 +5495,22 @@ ursgal_params = {
         ],
         'uvalue_option' : {
             'none_val'  : None,
-            'max'       : 1,
+            'max'       : 10000,
             'min'       : 0,
-            'updownval' : 1,
+            'f-point'   : 1e-02,
+            'updownval' : 0.1,
             'unit'      : ''
         },
         'uvalue_translation' : {
         },
-        'uvalue_type' : "int",
+        'uvalue_type' : "float",
     },
     'msfragger_zero_bin_mult_expect' : {
         'edit_version'   : 1.00,
         'available_in_unode' : [
             'msfragger_20170103',
         ],
-        'default_value' : 1,
+        'default_value' : 1.0,
         'description' :  ''' Multiplies expect value of PSMs in the zero-bin during results ordering (set to less than 1 for boosting) ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
@@ -5571,21 +5520,22 @@ ursgal_params = {
         ],
         'uvalue_option' : {
             'none_val'  : None,
-            'max'       : 10000000,
+            'max'       : 10000,
             'min'       : 0,
-            'updownval' : 1,
+            'f-point'   : 1e-02,
+            'updownval' : 0.1,
             'unit'      : ''
         },
         'uvalue_translation' : {
         },
-        'uvalue_type' : "int",
+        'uvalue_type' : "float",
     },
     'msfragger_add_topN_complementary' : {
         'edit_version'   : 1.00,
         'available_in_unode' : [
             'msfragger_20170103',
         ],
-        'default_value' : 0,
+        'default_value' : False,
         'description' :  ''' Inserts complementary ions corresponding to the top N most intense fragments in each experimental spectra. Useful for recovery of modified peptides near C-terminal in open search. Should be set to 0 (disabled) otherwise. ''',
         'triggers_rerun' : True,
         'ukey_translation' : {
@@ -5594,15 +5544,14 @@ ursgal_params = {
         'utag' : [
         ],
         'uvalue_option' : {
-            'none_val'  : None,
-            'max'       : 10000000,
-            'min'       : 0,
-            'updownval' : 1,
-            'unit'      : ''
         },
         'uvalue_translation' : {
+            'msfragger_style_1' : {
+                False : 0,
+                True : 1,
+            }
         },
-        'uvalue_type' : "int",
+        'uvalue_type' : "bool",
     },
     'msfragger_min_fragments_modelling' : {
         'edit_version'   : 1.00,

--- a/ursgal/wrappers/kojak_1_5_3.py
+++ b/ursgal/wrappers/kojak_1_5_3.py
@@ -227,8 +227,8 @@ percolator_version  =   {kojak_percolator_version}
 enrichment      =   {kojak_enrichment}       #Values between 0 and 1 to describe 18O APE.
                             #For example, 0.25 equals 25 APE.
 instrument      =   {instrument}       #Values are: 0=Orbitrap, 1=FTICR (such as Thermo LTQ-FT)
-MS1_centroid    =   {ms1_centroided}       #0=no, 1=yes
-MS2_centroid    =   {ms2_centroided}        #0=no, 1=yes
+MS1_centroid    =   {ms1_is_centroided}       #0=no, 1=yes
+MS2_centroid    =   {ms2_is_centroided}        #0=no, 1=yes
 MS1_resolution  =   {ms1_resolution}    #Resolution at 400 m/z, value ignored if data are
                             #already centroided
 MS2_resolution  =   {ms2_resolution}    #Resolution at 400 m/z, value ignored if data are

--- a/ursgal/wrappers/moda_v1_51.py
+++ b/ursgal/wrappers/moda_v1_51.py
@@ -25,7 +25,7 @@ class moda_v1_51(ursgal.UNode):
         'input_extensions': ['.mgf', '.pkl', '.dta', '.mzXML'],
         'output_extensions': ['.csv'],
         'create_own_folder': True,
-        'in_development': True,
+        'in_development': False,
         'include_in_git': False,
         'distributable': False,
         'utranslation_style': 'moda_style_1',

--- a/ursgal/wrappers/pyqms_1_0_0.py
+++ b/ursgal/wrappers/pyqms_1_0_0.py
@@ -15,7 +15,7 @@ class pyqms_1_0_0(ursgal.UNode):
         'version'            : '1.0.0',
         'release_date'       : None,
         'engine_type'        : {
-            'quantitation_engine' : True
+            'quantification_engine' : True
         },
         'utranslation_style' : 'pyqms_style_1',
         'citation'           : 'Leufken J, Niehues A, Sarin LP, Wessel F, Hippler M, Leidel SA, Fufezan C (2017) pyQms enables universal and accurate quantification of mass spectrometry data',
@@ -41,7 +41,7 @@ class pyqms_1_0_0(ursgal.UNode):
 
     def _execute(self):
         """run."""
-        print('[ -ENGINE- ] Executing quantitation ..')
+        print('[ -ENGINE- ] Executing quantification ..')
         self.time_point(tag='execution')
 
         main = self.import_engine_as_python_function()
@@ -125,7 +125,7 @@ class pyqms_1_0_0(ursgal.UNode):
             mzml_file=mzml_files,
             output_file=output_file,
             fixed_labels=fixed_labels,
-            evidence_files=self.params['quantitation_evidences'],
+            evidence_files=self.params['quantification_evidences'],
             molecules=self.params['molecules_to_quantify'],
             rt_border_tolerance=self.params['rt_border_tolerance'],
             label=self.params['label'],


### PR DESCRIPTION
- uparams_to_dash.py script added to create a local searchable uparams docu
- utags unified and updated
- quantitation replaced by quantification
- stripped ".u" when creating output_file_name for multi input files, e.g. unified_validated.u_merged.csv is now unified_validated_merged.csv