### PR TITLE
fix small bug in pepnovo postflight

### DIFF
--- a/ursgal/wrappers/pepnovo_3_1.py
+++ b/ursgal/wrappers/pepnovo_3_1.py
@@ -274,6 +274,8 @@ class pepnovo_3_1( ursgal.UNode ):
                     result_dict[line_list[2]] = []
                     id_list.append(line_list[2])
                     spectrumtitle_list.append(line_list[3])
+                if 'No solutions found' in line:
+                    continue
                 if line.startswith('#') and save_headers == True:
                     headers = line.strip('\n').split('\t')
                     save_headers = False


### PR DESCRIPTION
When pepnovo does not find a solution for the first spectrum, headers are not parsed properly.
Stefan suggested this small fix and it works like a charm for me.