### PR TITLE
Fix docs.

### DIFF
--- a/docs/source/example_scripts.txt
+++ b/docs/source/example_scripts.txt
@@ -128,10 +128,10 @@ MSGF+ version comparison
 Bruderer et al. (2015) X!Tandem comparison incl. machine ppm offset
 -------------------------------------------------------------------
 
-.. autofunction:: qexactive_xtandem_version_comparison.main
+.. autofunction:: xtandem_version_comparison_qexactive.main
 
 
-.. include:: code_inc/qexactive_xtandem_version_comparison.inc
+.. include:: code_inc/xtandem_version_comparison_qexactive.inc
 
 
 

--- a/docs/source/other_engines.txt
+++ b/docs/source/other_engines.txt
@@ -141,9 +141,7 @@ Quantification Engines
 pyQms 1_0_0
 -----------
 
-.. autoclass:: ursgal.resources.platform_independent.arc_independent.pyqms_1_0_0.pyqms_1_0_0
-   :members:
-   :private-members:
+.. autofunction:: ursgal.resources.platform_independent.arc_independent.pyqms_1_0_0.pyqms_1_0_0.main
 
 
 

--- a/ursgal/resources/platform_independent/arc_independent/mascot_dat2csv_1_0_0/mascot_dat2csv_1_0_0.py
+++ b/ursgal/resources/platform_independent/arc_independent/mascot_dat2csv_1_0_0/mascot_dat2csv_1_0_0.py
@@ -109,7 +109,7 @@ class MascotDatParser(object):
                 else:
                     raise Exception(
                         'Do not know what to do with this line'
-                        f'\n{line}'
+                        '\n{line}'.format(line=line)
                     )
         return pep_info
 
@@ -217,7 +217,7 @@ class MascotDatParser(object):
             raise Exception(
                 'reading mgf with CZ title under windows is not'
                 'supported now due to strange hex strings'
-                f'Title string supplied: {title}'
+                'Title string supplied: {title}'.format(title=title)
             )
         for e in entry_list:
             k_v = e.split('%3a')


### PR DESCRIPTION
Removed format strings, corrected filename and corrected autodoc usage.
I still get some warnings, they are found in a file generated by the uparams_to_sphinx_docu.py