### PR TITLE
Update setup.py to use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-from distutils.core import setup
-import distutils
-from distutils.command.install_lib import install_lib
+from setuptools import setup
+import setuptools
+from setuptools.command.install_lib import install_lib
 import os
 import sys
 
@@ -25,18 +25,18 @@ executable_list = [
 ]
 
 if sys.platform in ['win32']:
-    class my_install_lib(distutils.command.install_lib.install_lib):
+    class my_install_lib(setuptools.command.install_lib.install_lib):
         pass
 else:
-    class my_install_lib(distutils.command.install_lib.install_lib):
+    class my_install_lib(setuptools.command.install_lib.install_lib):
         def run(self):
-            distutils.command.install_lib.install_lib.run(self)
+            setuptools.command.install_lib.install_lib.run(self)
             for fn in self.get_outputs():
                 print('>>>>>>>>>>>>>>>>>>>', fn )
                 if os.path.basename(fn) in executable_list:
-                    # copied from distutils source - make the binaries executable
+                    # copied from setuptools source - make the binaries executable
                     mode = ((os.stat(fn).st_mode) | 0o555) & 0o7777
-                    distutils.log.info("changing mode of %s to %o", fn, mode)
+                    setuptools.log.info("changing mode of %s to %o", fn, mode)
                     os.chmod(fn, mode)
 
 


### PR DESCRIPTION
Replaced distutils by setuptools.
This is recommended by the community as described here: https://packaging.python.org/guides/tool-recommendations/

Also, this enables many useful features like building wheels, entry points and `python setup.py develop` .