### PR TITLE
Implement custom exceptions

### DIFF
--- a/tests/custom_exceptions_tests.py
+++ b/tests/custom_exceptions_tests.py
@@ -4,7 +4,7 @@ import os
 from nose.tools import raises
 
 import ursgal
-from ursgal.exceptions import UrsgalError, EmptyUrsgalCsvError
+from ursgal.exceptions import UrsgalError, EmptylCsvUrsgaError
 
 database = os.path.join("tests", "data", "BSA.fasta")
 test_file = os.path.join("tests", "data", "empty_search_results.csv")
@@ -12,7 +12,7 @@ R = ursgal.UController(params={"database": database})
 print("set up stuff")
 
 
-@raises(EmptyUrsgalCsvError)
+@raises(EmptylCsvUrsgaError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v4_test():
     R = ursgal.UController(
         params={
@@ -34,7 +34,7 @@ def empty_file_raises_UrsgalError_in_peptide_mapper_v4_test():
     R.map_peptides_to_fasta(test_file, force=True)
 
 
-@raises(EmptyUrsgalCsvError)
+@raises(EmptylCsvUrsgaError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v3_test():
     R = ursgal.UController(
         params={
@@ -56,7 +56,7 @@ def empty_file_raises_UrsgalError_in_peptide_mapper_v3_test():
     R.map_peptides_to_fasta(test_file, force=True)
 
 
-@raises(EmptyUrsgalCsvError)
+@raises(EmptylCsvUrsgaError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v2_test():
     R = ursgal.UController(
         params={

--- a/tests/custom_exceptions_tests.py
+++ b/tests/custom_exceptions_tests.py
@@ -4,7 +4,7 @@ import os
 from nose.tools import raises
 
 import ursgal
-from ursgal.exceptions import UrsgalError, EmptylCsvUrsgaError
+from ursgal.exceptions import UrsgalError, EmptyCsvUrsgalError
 
 database = os.path.join("tests", "data", "BSA.fasta")
 test_file = os.path.join("tests", "data", "empty_search_results.csv")
@@ -12,7 +12,7 @@ R = ursgal.UController(params={"database": database})
 print("set up stuff")
 
 
-@raises(EmptylCsvUrsgaError)
+@raises(EmptyCsvUrsgalError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v4_test():
     R = ursgal.UController(
         params={
@@ -34,7 +34,7 @@ def empty_file_raises_UrsgalError_in_peptide_mapper_v4_test():
     R.map_peptides_to_fasta(test_file, force=True)
 
 
-@raises(EmptylCsvUrsgaError)
+@raises(EmptyCsvUrsgalError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v3_test():
     R = ursgal.UController(
         params={
@@ -56,7 +56,7 @@ def empty_file_raises_UrsgalError_in_peptide_mapper_v3_test():
     R.map_peptides_to_fasta(test_file, force=True)
 
 
-@raises(EmptylCsvUrsgaError)
+@raises(EmptyCsvUrsgalError)
 def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v2_test():
     R = ursgal.UController(
         params={

--- a/tests/custom_exceptions_tests.py
+++ b/tests/custom_exceptions_tests.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import os
+
+from nose.tools import raises
+
+import ursgal
+from ursgal.exceptions import UrsgalError, EmptyUrsgalCsvError
+
+database = os.path.join("tests", "data", "BSA.fasta")
+test_file = os.path.join("tests", "data", "empty_search_results.csv")
+R = ursgal.UController(params={"database": database})
+print("set up stuff")
+
+
+@raises(EmptyUrsgalCsvError)
+def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v4_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v4",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)
+
+
+@raises(UrsgalError)
+def empty_file_raises_UrsgalError_in_peptide_mapper_v4_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v4",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)
+
+
+@raises(EmptyUrsgalCsvError)
+def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v3_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v3",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)
+
+
+@raises(UrsgalError)
+def empty_file_raises_UrsgalError_in_peptide_mapper_v3_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v3",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)
+
+
+@raises(EmptyUrsgalCsvError)
+def empty_file_raises_EmptyUrsgalCsvError_in_peptide_mapper_v2_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v2",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)
+
+
+@raises(UrsgalError)
+def empty_file_raises_UrsgalError_in_peptide_mapper_v2_test():
+    R = ursgal.UController(
+        params={
+            "database": database,
+            "peptide_mapper_class_version": "UPeptideMapper_v2",
+        }
+    )
+    R.map_peptides_to_fasta(test_file, force=True)

--- a/tests/data/empty_search_results.csv
+++ b/tests/data/empty_search_results.csv
@@ -1,0 +1,1 @@
+Sequence, Modifications,

--- a/ursgal/exceptions.py
+++ b/ursgal/exceptions.py
@@ -7,7 +7,7 @@ class UrsgalError(Exception):
     pass
 
 
-class EmptyUrsgalCsvError(UrsgalError):
+class EmptyCsvUrsgalError(UrsgalError):
     """Input CSV to ursgal node is empty"""
 
     pass

--- a/ursgal/exceptions.py
+++ b/ursgal/exceptions.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+
+class UrsgalError(Exception):
+    """Base class for all ursgal errors"""
+
+    pass
+
+
+class EmptyUrsgalCsvError(UrsgalError):
+    """Input CSV to ursgal node is empty"""
+
+    pass

--- a/ursgal/resources/platform_independent/arc_independent/upeptide_mapper_1_0_0/upeptide_mapper_1_0_0.py
+++ b/ursgal/resources/platform_independent/arc_independent/upeptide_mapper_1_0_0/upeptide_mapper_1_0_0.py
@@ -222,6 +222,11 @@ def main(input_file=None, output_file=None, params=None):
                 csv_file_buffer.append(line_dict)
             tmp_peptide_set.add( line_dict['Sequence'] )
         num_peptides = len(tmp_peptide_set)
+        if num_peptides == 0:
+            # delete already created outputfiles
+            os.remove(output_file)
+            os.remove(output_file + '_full_protein_names.txt')
+            raise ursgal.exceptions.EmptyUrsgalCsvError("Empty Input file, cant map peptides.")
         print('''[ map_peps ] Parsing and buffering csv done''')
         print(
             '''[ map_peps ] Mapping {0} peptides using mapper {1}'''.format(

--- a/ursgal/resources/platform_independent/arc_independent/upeptide_mapper_1_0_0/upeptide_mapper_1_0_0.py
+++ b/ursgal/resources/platform_independent/arc_independent/upeptide_mapper_1_0_0/upeptide_mapper_1_0_0.py
@@ -223,10 +223,7 @@ def main(input_file=None, output_file=None, params=None):
             tmp_peptide_set.add( line_dict['Sequence'] )
         num_peptides = len(tmp_peptide_set)
         if num_peptides == 0:
-            # delete already created outputfiles
-            os.remove(output_file)
-            os.remove(output_file + '_full_protein_names.txt')
-            raise ursgal.exceptions.EmptyUrsgalCsvError("Empty Input file, cant map peptides.")
+            raise ursgal.exceptions.EmptyCsvUrsgalError("Empty Input file, cant map peptides.")
         print('''[ map_peps ] Parsing and buffering csv done''')
         print(
             '''[ map_peps ] Mapping {0} peptides using mapper {1}'''.format(


### PR DESCRIPTION
- add ursgal/exceptions.py to collect ursgal specific exceptions
- raise custom exceptions in upeptide_mapper_1_0_0, if input file
contains no sequences to map
- add tests that check that all peptide_mappers raise UrsgalError and
EmptyUrsgalCsvError
- addresses #120 

I opened the pull request against dev, since we wanted to adapt the gitflow workflow