### PR TITLE
Update deepnovo_0_0_1.py

### DIFF
--- a/ursgal/wrappers/deepnovo_0_0_1.py
+++ b/ursgal/wrappers/deepnovo_0_0_1.py
@@ -281,7 +281,7 @@ class deepnovo_0_0_1(ursgal.UNode):
                          'N,opt,any,Deamidated',
                          'Q,opt,any,Deamidated']
                     [ ERROR ] You specified instead: {0}
-                    '''.format(deepnovo_param)
+                    '''.format(param_value)
                 #     cc = ursgal.ChemicalComposition()
                 #     for mod_dict in self.params['mods']['opt']:
                 #         '''


### PR DESCRIPTION
- print modifications value instead of param name when wrong modifications are set