### PR TITLE
Update unify_csv_1_0_0.py

### DIFF
--- a/ursgal/resources/platform_independent/arc_independent/unify_csv_1_0_0/unify_csv_1_0_0.py
+++ b/ursgal/resources/platform_independent/arc_independent/unify_csv_1_0_0/unify_csv_1_0_0.py
@@ -470,7 +470,7 @@ def main(
                 if params["prefix"] is None or params["prefix"] == "":
                     pass
                 elif input_file_basename.startswith(params["prefix"]):
-                    input_file_basename = line_2_split.replace(
+                    input_file_basename = input_file_basename.replace(
                         params["prefix"] + "_", ""
                     )
                 spectrum_id = line_dict["Spectrum ID"]


### PR DESCRIPTION
- fix replacing of prefix in input_file_basename for `MSFragger`, `Novor`,  `DeepNovo` and `TagGraph`