### PR TITLE
Allow multiple modifications at the same site

### DIFF
--- a/ursgal/resources/platform_independent/arc_independent/unify_csv_1_0_0/unify_csv_1_0_0.py
+++ b/ursgal/resources/platform_independent/arc_independent/unify_csv_1_0_0/unify_csv_1_0_0.py
@@ -1108,13 +1108,6 @@ def main(
                     line_dict_update["Modifications"] = ";".join(
                         ["{m}:{p}".format(m=mod, p=pos) for pos, mod in tmp]
                     )
-                    if len(tmp) != len(positions):
-                        print(
-                            "[ WARNING ] {Sequence}#{Modifications} will be skipped, because it contains two mods at the same position!".format(
-                                **line_dict_update
-                            )
-                        )
-                        continue
 
                 all_molecules.add(
                     "{Sequence}#{Modifications}".format(**line_dict_update)


### PR DESCRIPTION
- since `ursgal.chemical_composition.ChemicalComposition` now allows multiple modifications at the same site, and some engines do to (e.g. msfragger), we should also allow it in unify csv

Proof that it works with `ursgal.chemical_composition.ChemicalComposition`:
```
In [3]: import ursgal                                                                        

In [4]: from ursgal.chemical_composition import ChemicalComposition                          

In [5]: ursgal.__version__                                                                   
Out[5]: '0.6.8'

In [6]: s1 = 'C#Carbamidomethyl:1'                                                           

In [7]: s2 = 'C#Carbamidomethyl:1;Sulfide:1'                                                 

In [8]: cc1 = ChemicalComposition(s1)                                                        

In [9]: cc1                                                                                  
Out[9]: {'C': 5, 'H': 10, 'N': 2, 'O': 3, 'S': 1}

In [10]: cc2 = ChemicalComposition(s2)                                                       

In [11]: cc2                                                                                 
Out[11]: {'C': 5, 'H': 10, 'N': 2, 'O': 3, 'S': 2}
```
