### PR TITLE
releax version restrictions for install_requires

### DIFF
--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,0 +1,4 @@
+pymzml>=2.4,<3 
+regex
+pyahocorasick >= 1.1.4; sys_platform != 'win32'
+pyqms~=0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-pymzml==2.4.6
-nose==1.3.7
-regex
-pyahocorasick >= 1.1.4; sys_platform != 'win32'
-pyqms==0.6.2
-coverage
-codecov
-tox
-pre-commit

--- a/requirements/install_requires.txt
+++ b/requirements/install_requires.txt
@@ -1,4 +1,4 @@
 pymzml>=2.4,<3 
 regex
 pyahocorasick >= 1.1.4; sys_platform != 'win32'
-pyqms~=0.6.4
+pyqms~=0.6.2

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,0 +1,6 @@
+nose==1.3.7
+coverage
+codecov
+tox
+pre-commit
+-r install_requires.txt

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ version_path = os.path.join(os.path.dirname(__file__), "ursgal", "version.txt")
 with open(version_path, "r") as version_file:
     ursgal_version = version_file.read().strip()
 
-with open("install_requires.txt") as req:
+with open("requirements/install_requires.txt") as req:
     requirements = req.readlines()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ version_path = os.path.join(os.path.dirname(__file__), "ursgal", "version.txt")
 with open(version_path, "r") as version_file:
     ursgal_version = version_file.read().strip()
 
-with open("requirements.txt") as req:
+with open("install_requires.txt") as req:
     requirements = req.readlines()
 
 setup(


### PR DESCRIPTION
This PR relaxes the install_requires definitions in setup.py to allow pip more flexibility in solving environments. 

See issue #190 