### PR TITLE
fix percolator PSM mapping

### DIFF
--- a/ursgal/wrappers/percolator_3_2_1.py
+++ b/ursgal/wrappers/percolator_3_2_1.py
@@ -390,9 +390,7 @@ class percolator_3_2_1(ursgal.UNode):
                         self.params["_score_list"], score
                     )
                 else:
-                    rank_of_score = bisect.bisect_left(
-                        self.params["_score_list"], score
-                    )
+                    rank_of_score = bisect.bisect_left(self.params["_score_list"], score)
                     rank_of_score = len(self.params["_score_list"]) - rank_of_score
 
                 t["lnrSp"] = math.log(1 + rank_of_score)
@@ -568,9 +566,7 @@ class percolator_3_2_1(ursgal.UNode):
                     s2l[pkey][psmid_pep_key] = line_dict
 
         opened_file = open(self.params["translations"]["csv_input_file"], "r")
-        csv_input = csv.DictReader(
-            row for row in opened_file if not row.startswith("#")
-        )
+        csv_input = csv.DictReader(row for row in opened_file if not row.startswith("#"))
 
         if "PEP" not in csv_input.fieldnames and "q-value" not in csv_input.fieldnames:
             csv_input.fieldnames += ["PEP", "q-value", "Percolator:SVM Score"]
@@ -592,9 +588,7 @@ class percolator_3_2_1(ursgal.UNode):
             #  os.path.exists(self.params['translations']['protein_output_decoy']):
             with open(
                 self.params["translations"]["protein_output_target"]
-            ) as fin1, open(
-                self.params["translations"]["protein_output_decoy"]
-            ) as fin2:
+            ) as fin1, open(self.params["translations"]["protein_output_decoy"]) as fin2:
                 target_proteins_reader = csv.DictReader(fin1, delimiter="\t")
                 decoy_proteins_reader = csv.DictReader(fin2, delimiter="\t")
 
@@ -638,7 +632,7 @@ class percolator_3_2_1(ursgal.UNode):
             else:
                 seq_and_mods = line_dict["Sequence"]
             _psmid_pep_key = (
-                line_dict["Spectrum Title"],
+                line_dict["Spectrum Title"].replace(" ", "_"),
                 seq_and_mods,
             )
             if _psmid_pep_key in s2l[psm_type].keys():


### PR DESCRIPTION
Percolator replaces spaces with underscores in its output files. Therefore, if input spectrum titles contain a space, that will be an underscore in the reported PSM IDs and result in a failed mapping, since in Ursgal's unified format, spaces are preserved.

This PR fixes this issue during the mapping in Percolator postflight.